### PR TITLE
Add brackets so the strings aren't interpreted as an array of characters

### DIFF
--- a/examples/HpRestfulApiExamples.py
+++ b/examples/HpRestfulApiExamples.py
@@ -2039,7 +2039,7 @@ print('NOTE:  Remove the sys.exit call here to run the test cases.')
 sys.exit(-1)
 
 if False:
-    ex1_change_bios_setting(host, 'AdminName', 'Mr. Rest', iLO_loginname, iLO_password, bios_password)
+    ex1_change_bios_setting(host, ['AdminName'], ['Mr. Rest'], iLO_loginname, iLO_password, bios_password)
     ex2_reset_server(host, iLO_loginname, iLO_password)
     ex3_enable_secure_boot(host, False, iLO_loginname, iLO_password)
     ex4_bios_revert_default(host, iLO_loginname, iLO_password)
@@ -2184,4 +2184,4 @@ if False:
     instance = ex35_set_bios_iscsi(host, iLO_loginname, iLO_password, desired_iscsi_settings)
     if instance != -1:
         print("Created new iSCSI attempt (instance {})".format(instance))
-    
+   


### PR DESCRIPTION
While running the ex1, the following output is generated:

```
Tutorial Examples 0.9.13 BETA for HP RESTful API
Copyright 2002-2014 Hewlett-Packard Development Company, L.P.
For more information see www.hp.com/go/restfulapi
Uncomment the ex* functions in the script file to see use case examples
NOTE:  Remove the sys.exit call here to run the test cases.
EXAMPLE 1:  Change a BIOS setting
    BIOS Property "A" is not supported on this system

```

The string 'AdminName' is interpreted as an array of chars, adding brackets resolves this
